### PR TITLE
Update module name to allow importing by other packages

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"cronitor/lib"
+	"github.com/cronitorio/cronitor-cli/lib"
 	"errors"
 	"fmt"
 	"os"

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"cronitor/lib"
+	"github.com/cronitorio/cronitor-cli/lib"
 	"fmt"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"cronitor/lib"
+	"github.com/cronitorio/cronitor-cli/lib"
 	"errors"
 	"fmt"
 	"io/ioutil"

--- a/cmd/select.go
+++ b/cmd/select.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"cronitor/lib"
+	"github.com/cronitorio/cronitor-cli/lib"
 	"fmt"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module cronitor
+module github.com/cronitorio/cronitor-cli
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"cronitor/cmd"
+	"github.com/cronitorio/cronitor-cli/cmd"
 	"github.com/getsentry/raven-go"
 	"os"
 )


### PR DESCRIPTION
## Summary
Update the name of the `cronitor-cli` Go module from `cronitor` to `github.com/cronitorio/cronitor-cli`.

## Reasoning
The CLI repo contains sub-packages with code that could be useful for other projects in integrating with the Cronitor API. In the absence of an official [Go Cronitor SDK](https://cronitor.io/docs/sdks), the code here is a useful fallback, and so the package should be importable.

With the name `cronitor`, the package cannot be imported (at least) when using Go modules.