### PR TITLE
Document MCP server in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,99 @@ cronitor configure --users user1,user2
 ```
 For systemd and Docker examples, and security best‑practices, see the full [Dashboard documentation](https://crontab.guru/dashboard.html).
 
+## MCP Server (AI Integration)
+
+The Cronitor CLI includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server, enabling integration with AI-powered development tools like Claude Code, Cursor, Cline, Windsurf, and others. Manage your cron jobs using natural language directly from your editor or terminal.
+
+### How It Works
+
+The MCP integration has two components:
+1. **Dashboard** - The web UI (`cronitor dash`) that must be running to manage cron jobs
+2. **MCP Server** - A bridge process (`cronitor dash --mcp-instance`) that your AI tool spawns and communicates with via stdio; it connects to the dashboard over HTTP
+
+### Quick Setup
+
+1. **Start the dashboard** on the machine where your cron jobs run:
+   ```bash
+   # Set credentials first
+   cronitor configure --dash-username USER --dash-password PASS
+
+   # Start the dashboard (runs on port 9000)
+   cronitor dash
+   ```
+
+2. **Configure your MCP client** (Claude Code, Cursor, etc.) to spawn the MCP server:
+
+   Example configuration for tools using `mcp.json`:
+   ```json
+   {
+     "mcpServers": {
+       "cronitor": {
+         "command": "cronitor",
+         "args": ["dash", "--mcp-instance", "default"]
+       }
+     }
+   }
+   ```
+
+   The `default` instance connects to `localhost:9000` using your configured credentials.
+
+3. **Start using natural language** to manage your cron jobs!
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `create_cronjob` | Create a new cron job with name, command, and schedule |
+| `list_cronjobs` | List all cron jobs with optional filtering |
+| `update_cronjob` | Update an existing job's schedule, command, or status |
+| `delete_cronjob` | Delete a cron job |
+| `run_cronjob_now` | Execute a cron job immediately |
+| `get_cronitor_instance` | Get info about the current Cronitor instance |
+
+### Example Prompts
+
+- "Create a database backup job that runs every night at 2 AM"
+- "List all cron jobs containing 'backup'"
+- "Suspend the cleanup job"
+- "Run the backup job now"
+
+### Human-Readable Schedules
+
+The MCP server understands natural language schedules:
+- `"every 15 minutes"` → `*/15 * * * *`
+- `"every day at noon"` → `0 12 * * *`
+- `"every Monday at 10:30"` → `30 10 * * 1`
+- `"hourly"`, `"daily"`, `"weekly"`, `"monthly"`
+
+### Multi-Instance Support
+
+Connect to multiple Cronitor dashboards (dev, staging, production) by configuring instances in `~/.cronitor/cronitor.json`:
+
+```json
+{
+  "mcp_instances": {
+    "production": {
+      "url": "http://prod-server:9000",
+      "username": "admin",
+      "password": "password"
+    }
+  }
+}
+```
+
+Then configure separate MCP servers in your client for each instance.
+
+### Resources
+
+The MCP server also exposes resources for programmatic access:
+- `cronitor://crontabs` - All crontab files as JSON
+- `cronitor://jobs` - All cron jobs as JSON
+
+For complete documentation including SSH tunneling, custom prompts, and troubleshooting, see:
+- [MCP Integration Guide](docs/MCP_INTEGRATION.md)
+- [MCP Prompts Configuration](docs/MCP_PROMPTS.md)
+
 ## Uninstall CronitorCLI
 First, you will need to update any crontab files that were edited to include Cronitor to remove the reference to `cronitor exec MONITOR_KEY` that were added when you created monitors.
 

--- a/README.md
+++ b/README.md
@@ -81,96 +81,11 @@ For systemd and Docker examples, and security best‑practices, see the full [Da
 
 ## MCP Server (AI Integration)
 
-The Cronitor CLI includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server, enabling integration with AI-powered development tools like Claude Code, Cursor, Cline, Windsurf, and others. Manage your cron jobs using natural language directly from your editor or terminal.
+The Cronitor CLI includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for managing cron jobs with natural language through AI-powered tools like Claude Code, Cursor, Cline, and Windsurf.
 
-### How It Works
+**Quick start:** Run `cronitor dash` on your server, then configure your MCP client to spawn `cronitor dash --mcp-instance default`.
 
-The MCP integration has two components:
-1. **Dashboard** - The web UI (`cronitor dash`) that must be running to manage cron jobs
-2. **MCP Server** - A bridge process (`cronitor dash --mcp-instance`) that your AI tool spawns and communicates with via stdio; it connects to the dashboard over HTTP
-
-### Quick Setup
-
-1. **Start the dashboard** on the machine where your cron jobs run:
-   ```bash
-   # Set credentials first
-   cronitor configure --dash-username USER --dash-password PASS
-
-   # Start the dashboard (runs on port 9000)
-   cronitor dash
-   ```
-
-2. **Configure your MCP client** (Claude Code, Cursor, etc.) to spawn the MCP server:
-
-   Example configuration for tools using `mcp.json`:
-   ```json
-   {
-     "mcpServers": {
-       "cronitor": {
-         "command": "cronitor",
-         "args": ["dash", "--mcp-instance", "default"]
-       }
-     }
-   }
-   ```
-
-   The `default` instance connects to `localhost:9000` using your configured credentials.
-
-3. **Start using natural language** to manage your cron jobs!
-
-### Available Tools
-
-| Tool | Description |
-|------|-------------|
-| `create_cronjob` | Create a new cron job with name, command, and schedule |
-| `list_cronjobs` | List all cron jobs with optional filtering |
-| `update_cronjob` | Update an existing job's schedule, command, or status |
-| `delete_cronjob` | Delete a cron job |
-| `run_cronjob_now` | Execute a cron job immediately |
-| `get_cronitor_instance` | Get info about the current Cronitor instance |
-
-### Example Prompts
-
-- "Create a database backup job that runs every night at 2 AM"
-- "List all cron jobs containing 'backup'"
-- "Suspend the cleanup job"
-- "Run the backup job now"
-
-### Human-Readable Schedules
-
-The MCP server understands natural language schedules:
-- `"every 15 minutes"` → `*/15 * * * *`
-- `"every day at noon"` → `0 12 * * *`
-- `"every Monday at 10:30"` → `30 10 * * 1`
-- `"hourly"`, `"daily"`, `"weekly"`, `"monthly"`
-
-### Multi-Instance Support
-
-Connect to multiple Cronitor dashboards (dev, staging, production) by configuring instances in `~/.cronitor/cronitor.json`:
-
-```json
-{
-  "mcp_instances": {
-    "production": {
-      "url": "http://prod-server:9000",
-      "username": "admin",
-      "password": "password"
-    }
-  }
-}
-```
-
-Then configure separate MCP servers in your client for each instance.
-
-### Resources
-
-The MCP server also exposes resources for programmatic access:
-- `cronitor://crontabs` - All crontab files as JSON
-- `cronitor://jobs` - All cron jobs as JSON
-
-For complete documentation including SSH tunneling, custom prompts, and troubleshooting, see:
-- [MCP Integration Guide](docs/MCP_INTEGRATION.md)
-- [MCP Prompts Configuration](docs/MCP_PROMPTS.md)
+For setup instructions, available tools, and configuration options, see the [MCP Integration Guide](docs/MCP_INTEGRATION.md).
 
 ## Uninstall CronitorCLI
 First, you will need to update any crontab files that were edited to include Cronitor to remove the reference to `cronitor exec MONITOR_KEY` that were added when you created monitors.

--- a/docs/MCP_INTEGRATION.md
+++ b/docs/MCP_INTEGRATION.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Cronitor CLI now includes built-in support for the Model Context Protocol (MCP), enabling seamless integration with Cursor IDE and other LLM-powered development tools. This allows you to manage cron jobs using natural language directly from your code editor.
+Cronitor CLI includes built-in support for the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), enabling integration with AI-powered development tools like Claude Code, Cursor, Cline, Windsurf, and others. Manage cron jobs using natural language directly from your editor or terminal.
 
 ## Features
 
@@ -13,33 +13,81 @@ Cronitor CLI now includes built-in support for the Model Context Protocol (MCP),
 - **Resource Access**: Browse crontabs and jobs as MCP resources
 - **Secure Authentication**: Uses existing Cronitor dashboard credentials
 
-## Installation
+## How It Works
 
-The MCP server is included in the standard Cronitor CLI. Just ensure you have the latest version:
+The MCP integration has two components:
+
+1. **Dashboard** (`cronitor dash`) - The web UI that manages cron jobs. This **must be running on the server where your cron jobs live**.
+
+2. **MCP Server** (`cronitor dash --mcp-instance`) - A bridge process that your AI tool spawns locally. It communicates with your AI tool via stdio and connects to the dashboard over HTTP.
+
+```
+┌─────────────────────┐      stdio      ┌─────────────────────┐      HTTP       ┌─────────────────────┐
+│   AI Tool           │ ◄─────────────► │   MCP Server        │ ◄─────────────► │   Dashboard         │
+│   (Claude Code,     │                 │   (cronitor dash    │                 │   (cronitor dash)   │
+│    Cursor, etc.)    │                 │    --mcp-instance)  │                 │   on your server    │
+└─────────────────────┘                 └─────────────────────┘                 └─────────────────────┘
+      Your machine                           Your machine                           Your server
+```
+
+## Quick Start
+
+### Step 1: Start the Dashboard on Your Server
+
+On the machine where your cron jobs run, start the Cronitor dashboard:
 
 ```bash
-# Download the latest version
-curl -s https://cronitor.io/install | sudo bash
+# Set credentials for the dashboard
+cronitor configure --dash-username USER --dash-password PASS
 
-# Or build from source
-go build -o cronitor
+# Start the dashboard (runs on port 9000 by default)
+cronitor dash
 ```
+
+**Important:** The dashboard must be running and accessible for the MCP server to work. For production use, consider running it as a systemd service or in Docker.
+
+### Step 2: Configure Your MCP Client
+
+Configure your AI tool to spawn the Cronitor MCP server. Most MCP-compatible tools use a JSON configuration file.
+
+**Generic MCP configuration:**
+```json
+{
+  "mcpServers": {
+    "cronitor": {
+      "command": "cronitor",
+      "args": ["dash", "--mcp-instance", "default"]
+    }
+  }
+}
+```
+
+The `default` instance connects to `localhost:9000` using credentials from your Cronitor config file (`~/.cronitor/cronitor.json`).
+
+**Common configuration file locations:**
+- **Claude Code**: `~/.claude/mcp.json` or project `.claude/mcp.json`
+- **Cursor**: `~/.cursor/mcp.json` or project `.cursor/mcp.json`
+- **Other tools**: Check your tool's MCP documentation
+
+### Step 3: Start Using Natural Language
+
+Once configured, you can manage cron jobs with prompts like:
+- "Create a database backup job that runs every night at 2 AM"
+- "List all cron jobs containing 'backup'"
+- "Suspend the cleanup job"
+- "Run the backup job now"
 
 ## Configuration
 
-### 1. Configure Cronitor Instances
+### Cronitor Configuration File
 
-Edit your Cronitor configuration file (`~/.cronitor/cronitor.json`):
+Edit `~/.cronitor/cronitor.json` to configure dashboard credentials and additional instances:
 
 ```json
 {
     "CRONITOR_DASH_USER": "admin",
     "CRONITOR_DASH_PASS": "your-password",
     "mcp_instances": {
-        // Note: "default" instance automatically uses credentials from above
-        // No need to configure it - just use: cronitor dash --mcp-instance default
-        // It will connect to localhost:9000 with your dashboard credentials
-        
         "production": {
             "url": "http://prod-server.example.com:9000",
             "username": "prod-admin",
@@ -54,13 +102,11 @@ Edit your Cronitor configuration file (`~/.cronitor/cronitor.json`):
 }
 ```
 
-### 2. Configure Cursor IDE
+**Note:** The `default` instance automatically uses `CRONITOR_DASH_USER` and `CRONITOR_DASH_PASS` from your config and connects to `localhost:9000`. You don't need to configure it explicitly.
 
-Configure MCP servers in Cursor using one of these methods:
+### Multi-Instance Setup
 
-#### Option 1: Global Configuration (All Projects)
-
-Create `~/.cursor/mcp.json`:
+To connect to multiple dashboards, configure each as a separate MCP server:
 
 ```json
 {
@@ -81,9 +127,9 @@ Create `~/.cursor/mcp.json`:
 }
 ```
 
-#### Option 2: Project-Specific Configuration
+### Project-Specific Configuration
 
-Create `.cursor/mcp.json` in your project directory:
+You can override the config file path per-project using an environment variable:
 
 ```json
 {
@@ -99,15 +145,6 @@ Create `.cursor/mcp.json` in your project directory:
 }
 ```
 
-#### Option 3: Using Cursor's UI
-
-You can also configure MCP servers through Cursor's UI:
-1. Go to Settings → MCP
-2. Click "Add New MCP Server"
-3. Fill in the command and arguments
-
-Note: The `--mcp-instance` flag automatically enables MCP mode, so you don't need a separate `--mcp` flag.
-
 ## Available MCP Tools
 
 ### create_cronjob
@@ -117,16 +154,16 @@ Create a new cron job.
 - `name` (required): Name of the cron job
 - `command` (required): Command to execute
 - `schedule` (required): Cron expression or human-readable schedule
-- `crontab_file`: Target crontab file (default: user:<current_user>)
+- `crontab_file`: Target crontab file (default: user's personal crontab)
 - `monitored`: Enable Cronitor monitoring (default: false)
-- `run_as_user`: User to run the job as (only needed for system crontabs)
+- `run_as_user`: User to run the job as (only for system crontabs)
 
 **Example prompts:**
 - "Create a cron job called 'backup-db' that runs '/scripts/backup.sh' every day at 2 AM"
 - "Add a job to clean temp files every hour"
 
 ### list_cronjobs
-List all cron jobs.
+List all cron jobs with optional filtering.
 
 **Parameters:**
 - `filter`: Filter by name or command
@@ -143,8 +180,8 @@ Update an existing cron job.
 - `name`: New name
 - `command`: New command
 - `schedule`: New schedule
-- `suspended`: Suspend/resume the job
-- `monitored`: Enable/disable monitoring
+- `suspended`: Suspend/resume the job (boolean)
+- `monitored`: Enable/disable monitoring (boolean)
 
 **Example prompts:**
 - "Change the backup job to run every 6 hours"
@@ -183,48 +220,39 @@ Access all crontab files in JSON format.
 ### cronitor://jobs
 Access all cron jobs in JSON format.
 
-## Usage Examples
+## Human-Readable Schedules
 
-### Creating Jobs
+The MCP server understands both cron expressions and natural language schedules:
 
-**User:** "Create a database backup job that runs every night at 2 AM"
+| Natural Language | Cron Expression |
+|-----------------|-----------------|
+| `every minute` | `* * * * *` |
+| `every hour` | `0 * * * *` |
+| `every day` | `0 0 * * *` |
+| `every 15 minutes` | `*/15 * * * *` |
+| `every day at noon` | `0 12 * * *` |
+| `every Monday at 10:30` | `30 10 * * 1` |
+| `hourly` | `0 * * * *` |
+| `daily` | `0 0 * * *` |
+| `weekly` | `0 0 * * 0` |
+| `monthly` | `0 0 1 * *` |
 
-**Cursor will:**
-1. Use the `create_cronjob` tool
-2. Set appropriate parameters:
-   - name: "database-backup"
-   - command: (you'll need to specify)
-   - schedule: "0 2 * * *"
+## Remote Access
 
-### Managing Multiple Instances
+Since the dashboard runs on your server and the MCP server runs locally, you'll need network access to the dashboard. Here are common patterns:
 
-**With multiple MCP servers configured:**
+### SSH Tunnel (Recommended)
 
-**User:** "List all jobs on the production server"
+Create an SSH tunnel to securely access a remote dashboard:
 
-**Cursor will:**
-1. Use the production instance (`cronitor-prod`)
-2. Call `list_cronjobs` to show all jobs
-
-### Complex Schedules
-
-The MCP server understands both cron expressions and human-readable schedules:
-
-- "every 15 minutes" → `*/15 * * * *`
-- "every day at noon" → `0 12 * * *`
-- "every Monday at 10:30" → `30 10 * * 1`
-- "hourly" → `0 * * * *`
-
-## SSH and Remote Access
-
-For remote Cronitor instances accessed via SSH:
-
-### Option 1: SSH Tunnel
 ```bash
-# Create SSH tunnel
-ssh -L 9001:localhost:9000 user@remote-server
+# Create tunnel from local port 9001 to remote port 9000
+ssh -L 9001:localhost:9000 user@your-server
+```
 
-# Configure instance to use tunneled port
+Then configure the instance to use the tunneled port:
+
+```json
 {
   "mcp_instances": {
     "remote": {
@@ -236,55 +264,51 @@ ssh -L 9001:localhost:9000 user@remote-server
 }
 ```
 
-### Option 2: Direct SSH in Cursor Config
+### Direct SSH Transport
+
+Some MCP clients support running commands over SSH directly:
+
 ```json
 {
   "mcpServers": {
     "cronitor-remote": {
       "command": "ssh",
       "args": [
-        "user@remote-server",
-        "cronitor dash --mcp"
+        "user@your-server",
+        "cronitor dash --mcp-instance default"
       ]
     }
   }
 }
 ```
 
+This runs the MCP server on the remote machine and pipes stdio over SSH.
+
 ## Environment Variables
 
-The MCP server respects all standard Cronitor environment variables:
+The MCP server respects these environment variables:
 
-- `CRONITOR_CONFIG`: Path to config file
-- `CRONITOR_MCP_ENABLED`: Enable MCP mode
-- `CRONITOR_MCP_INSTANCE`: Default instance name
-- `CRONITOR_DASH_USER`: Dashboard username
-- `CRONITOR_DASH_PASS`: Dashboard password
-
-## Persistent Rules and Instructions
-
-You can configure persistent rules and instructions that will always be used when interacting with the MCP server. See [MCP_PROMPTS.md](MCP_PROMPTS.md) for detailed configuration options including:
-
-- Cursor rules (`.cursorrules` file)
-- Project-specific MCP configuration
-- Built-in system prompts
-- Custom instance prompts
+| Variable | Description |
+|----------|-------------|
+| `CRONITOR_CONFIG` | Path to config file |
+| `CRONITOR_MCP_INSTANCE` | Default instance name |
+| `CRONITOR_DASH_USER` | Dashboard username |
+| `CRONITOR_DASH_PASS` | Dashboard password |
 
 ## Troubleshooting
 
-### Test MCP Server
+### Test the MCP Server
+
 ```bash
 # Test MCP server startup with default instance
 cronitor dash --mcp-instance default
 
 # Test with specific instance
 cronitor dash --mcp-instance production
-
-# Legacy format (still supported)
-cronitor dash --mcp
 ```
 
 ### Check Configuration
+
 ```bash
 # View current configuration
 cronitor configure
@@ -292,35 +316,43 @@ cronitor configure
 
 ### Common Issues
 
-1. **"No Cronitor instance configured"**
-   - Ensure your config file has the correct instance settings
-   - Check that the instance name matches
+**"No Cronitor instance configured"**
+- Ensure your config file has the correct instance settings
+- Check that the instance name matches what you configured
 
-2. **"Authentication failed (401 Error)"**
-   - For "default" instance: Ensure CRONITOR_DASH_USER and CRONITOR_DASH_PASS are set in your config
-   - For other instances: Verify username and password in the mcp_instances section
-   - Ensure the dashboard is running and accessible
+**"Authentication failed (401 Error)"**
+- For `default` instance: Ensure `CRONITOR_DASH_USER` and `CRONITOR_DASH_PASS` are set in your config
+- For other instances: Verify username and password in the `mcp_instances` section
+- Ensure the dashboard is running and accessible
 
-3. **"CSRF token validation failed (403 Error)"**
-   - This is handled automatically by the MCP server
-   - If it persists, try restarting the dashboard
-   - The MCP server fetches a fresh CSRF token before each state-changing request
+**"Connection refused"**
+- Check that the dashboard URL is correct
+- Verify the dashboard is running: `cronitor dash` in another terminal
+- Check network connectivity and any firewalls
+- For remote dashboards, ensure your SSH tunnel is active
 
-4. **"Connection refused"**
-   - Check that the dashboard URL is correct
-   - Verify the dashboard is actually running (`cronitor dash` in another terminal)
-   - Verify network connectivity to the dashboard
+**"CSRF token validation failed (403 Error)"**
+- This is usually handled automatically by the MCP server
+- If it persists, try restarting the dashboard
 
 ## Security Considerations
 
 - MCP servers run with the permissions of the user executing them
-- Dashboard credentials are stored in the config file - protect it appropriately
-- Use SSH tunnels or VPNs for remote instances
+- Dashboard credentials are stored in the config file - protect it with appropriate file permissions
+- Use SSH tunnels or VPNs for remote access rather than exposing the dashboard directly
 - Consider using separate credentials for different environments
+
+## Persistent Rules and Instructions
+
+You can configure persistent rules that guide how your AI tool interacts with the MCP server. See [MCP_PROMPTS.md](MCP_PROMPTS.md) for details on:
+
+- Project-specific rules files
+- Custom system prompts per instance
+- Best practices for different environments
 
 ## Support
 
 For issues or questions:
 - Check the [Cronitor documentation](https://cronitor.io/docs)
 - Review the [MCP specification](https://modelcontextprotocol.io)
-- Open an issue on the [Cronitor CLI GitHub repository](https://github.com/cronitorio/cronitor-cli) 
+- Open an issue on the [Cronitor CLI GitHub repository](https://github.com/cronitorio/cronitor-cli)

--- a/docs/MCP_PROMPTS.md
+++ b/docs/MCP_PROMPTS.md
@@ -4,16 +4,25 @@ This guide explains how to configure persistent rules and instructions for the C
 
 ## Overview
 
-There are several ways to add persistent rules and instructions that will always be used when interacting with the Cronitor MCP server:
+You can add persistent rules and instructions that guide how your AI tool interacts with the Cronitor MCP server. These rules help ensure consistent behavior, enforce best practices, and add safety guardrails for different environments.
 
-1. **Cursor Rules** (`.cursorrules` file)
-2. **Project-specific MCP Configuration** (`.cursor/mcp.json`)
-3. **Built-in System Prompts** (automatically applied based on instance)
-4. **Custom Instance Prompts** (via configuration)
+There are several ways to configure rules:
 
-## 1. Cursor Rules (Recommended)
+1. **Project Rules Files** (tool-specific rules files in your project)
+2. **MCP Server Configuration** (per-server instructions in `mcp.json`)
+3. **Built-in System Prompts** (automatically applied based on instance name)
+4. **Custom Instance Prompts** (via Cronitor configuration)
 
-Create a `.cursorrules` file in your project root with MCP-specific rules:
+## 1. Project Rules Files
+
+Most AI tools support project-specific rules files. Create a rules file in your project root with MCP-specific guidance:
+
+**Common rules file locations:**
+- **Claude Code**: `.claude/rules.md` or `CLAUDE.md`
+- **Cursor**: `.cursorrules`
+- **Other tools**: Check your tool's documentation
+
+**Example rules file content:**
 
 ```markdown
 # Cronitor MCP Rules
@@ -22,29 +31,34 @@ When using Cronitor MCP tools:
 
 ## Default Behavior
 - Always create jobs in the user's personal crontab unless explicitly specified otherwise
-- Use descriptive job names that clearly indicate the purpose, avoid underscores and use other special characters sparingly 
-- Disable Enable monitoring by default, but mention it after the job is created and suggest the user turn it on
-- When referencing the cronitor executable, by default it is installed systemwide and should just be called "cronitor" in commands. 
+- Use descriptive job names that clearly indicate the purpose
+- Monitoring is disabled by default - mention it after job creation and suggest enabling it
+- Use full paths for executables (except "cronitor" which is installed system-wide)
 
 ## Job Creation Guidelines
 - Ask the user if they want to test commands with "run_cronjob_now" after creation
-- Prefer explicit paths over relying on PATH environment variable, except for "cronitor"
+- Prefer explicit paths over relying on PATH environment variable
+- For web projects, use curl to invoke endpoints rather than running scripts directly
 
 ## Scheduling Best Practices
 - Avoid scheduling multiple heavy jobs at the same time
 - For daily jobs, prefer running between 2-4 AM local time
-- Use random minutes (not :00 or :30) to avoid load spikes
+- Use random minutes (not :00 or :30) to avoid load spikes on shared infrastructure
 
 ## Instance Selection
-- Users will often have multiple connected Cronitor MCP servers
 - Use "default" instance for local development
-- Always confirm which instance before making changes
+- Always confirm which instance before making changes to production
 - List existing jobs before creating new ones to avoid duplicates
+
+## Safety
+- Always use job KEY (not name) for update/delete operations
+- Ask for confirmation before destructive operations
+- Never modify jobs on production without explicit user confirmation
 ```
 
-## 2. Project-specific MCP Configuration
+## 2. MCP Server Configuration
 
-Add instructions to your `.cursor/mcp.json` file:
+You can add per-server instructions in your MCP configuration file. This is useful for adding environment-specific warnings or guidelines.
 
 ```json
 {
@@ -59,6 +73,23 @@ Add instructions to your `.cursor/mcp.json` file:
       "args": ["dash", "--mcp-instance", "production"],
       "description": "Production Cronitor - CAUTION: Changes affect live system!"
     }
+  }
+}
+```
+
+Some tools also support an `instructions` field for more detailed guidance:
+
+```json
+{
+  "mcpServers": {
+    "cronitor": {
+      "command": "cronitor",
+      "args": ["dash", "--mcp-instance", "default"]
+    },
+    "cronitor-production": {
+      "command": "cronitor",
+      "args": ["dash", "--mcp-instance", "production"]
+    }
   },
   "instructions": {
     "cronitor": {
@@ -71,7 +102,7 @@ Add instructions to your `.cursor/mcp.json` file:
     },
     "cronitor-production": {
       "guidelines": [
-        "⚠️ PRODUCTION INSTANCE - Changes are immediate!",
+        "PRODUCTION INSTANCE - Changes are immediate!",
         "Always list existing jobs before creating new ones",
         "Backup critical crontabs before making changes",
         "Coordinate with team before modifying shared jobs",
@@ -84,7 +115,7 @@ Add instructions to your `.cursor/mcp.json` file:
 
 ## 3. Built-in System Prompts
 
-The MCP server automatically applies instance-specific prompts based on the instance name:
+The MCP server automatically applies instance-specific prompts based on the instance name. These provide sensible defaults for common environments.
 
 ### Default Instance
 - Local development environment rules
@@ -102,27 +133,29 @@ The MCP server automatically applies instance-specific prompts based on the inst
 - Production mirroring guidelines
 - Alert configuration testing
 
-To see the current system prompt for an instance, use:
+To see the current system prompt for an instance, ask your AI tool:
 ```
 "Show me the current Cronitor instance information"
 ```
 
 ## 4. Custom Instance Prompts
 
-You can customize prompts for specific instances in your `~/.cronitor/cronitor.json`:
+You can add custom prompts for specific instances in your `~/.cronitor/cronitor.json`:
 
 ```json
 {
   "mcp_instances": {
     "production": {
-      "url": "http://localhost:9090",
+      "url": "http://prod-server:9000",
       "username": "admin",
       "password": "password",
-      "system_prompt": "Custom rules for this specific production instance:\n- Always notify #ops-channel before changes\n- No changes during business hours (9 AM - 5 PM EST)\n- All jobs must have error notifications enabled"
+      "system_prompt": "Custom rules for this production instance:\n- Always notify #ops-channel before changes\n- No changes during business hours (9 AM - 5 PM EST)\n- All jobs must have error notifications enabled"
     }
   }
 }
 ```
+
+This is useful for organization-specific policies or server-specific requirements.
 
 ## Best Practices for Rules
 
@@ -141,16 +174,27 @@ User: "Create a backup job for the database"
 
 AI Assistant (following rules):
 1. Checks current instance (development)
-2. Creates job with descriptive name: "mysql-database-backup"
-3. Schedules at 3:17 AM (avoiding common times)
-4. Includes error handling and logging
-5. Enables monitoring by default
-6. Tests with run_cronjob_now
+2. Lists existing jobs to avoid duplicates
+3. Creates job with descriptive name: "mysql-database-backup"
+4. Schedules at 3:17 AM (avoiding common times)
+5. Uses full path for backup script
+6. Leaves monitoring disabled but mentions it
+7. Asks if user wants to test with run_cronjob_now
 ```
+
+## Rule Priority
+
+When multiple rule sources exist, they're generally applied in this order (highest priority first):
+
+1. Direct user instructions in the current conversation
+2. Project rules files (`.cursorrules`, `CLAUDE.md`, etc.)
+3. MCP server configuration instructions
+4. Custom instance prompts in cronitor.json
+5. Built-in system prompts
 
 ## Troubleshooting
 
-- Rules in `.cursorrules` apply to all MCP interactions in the project
-- Project-specific `.cursor/mcp.json` overrides global settings
-- Built-in system prompts are always included
-- Use `get_cronitor_instance` to see active rules for current instance 
+- Project rules files apply to all MCP interactions in that project
+- MCP configuration instructions are per-server
+- Use `get_cronitor_instance` to see active rules for the current instance
+- If rules aren't being followed, check that your rules file is in the correct location for your AI tool


### PR DESCRIPTION
Document the built-in MCP server for AI integration with Claude Code, Cursor, Cline, Windsurf, and other MCP-compatible tools. Includes quick setup guide, available tools reference, example prompts, human-readable schedule syntax, and multi-instance support. Links to detailed docs in docs/ folder.