### PR TITLE
Fix deprecated rand.Seed and Crontab.Save pointer receiver bug

### DIFF
--- a/lib/crontab.go
+++ b/lib/crontab.go
@@ -28,7 +28,6 @@ type TimezoneLocationName struct {
 type Crontab struct {
 	User                    string                `json:"-"`
 	IsUserCrontab           bool                  `json:"isUserCrontab"`
-	IsSaved                 bool                  `json:"-"`
 	Filename                string                `json:"filename"`
 	Lines                   []*Line               `json:"-"`
 	TimezoneLocationName    *TimezoneLocationName `json:"timezone,omitempty"`
@@ -290,7 +289,6 @@ func (c *Crontab) Save(crontabLines string) error {
 		}
 	}
 
-	c.IsSaved = true
 	return nil
 }
 
@@ -920,7 +918,6 @@ func (c *Crontab) lightweightCopy() Crontab {
 	return Crontab{
 		User:                    c.User,
 		IsUserCrontab:           c.IsUserCrontab,
-		IsSaved:                 c.IsSaved,
 		Filename:                c.Filename,
 		Lines:                   nil, // Explicitly nil to break circular reference
 		TimezoneLocationName:    c.TimezoneLocationName,

--- a/lib/crontab.go
+++ b/lib/crontab.go
@@ -272,7 +272,7 @@ func (c Crontab) Write() string {
 	return result
 }
 
-func (c Crontab) Save(crontabLines string) error {
+func (c *Crontab) Save(crontabLines string) error {
 	if c.IsUserCrontab {
 		cmd := c.buildCrontabCommand("-")
 

--- a/lib/crontab_test.go
+++ b/lib/crontab_test.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -243,33 +242,6 @@ func TestLineWriteWithEnvFlag(t *testing.T) {
 	viper.Set("CRONITOR_ENV", originalEnv)
 }
 
-func TestSaveSetsIsSaved(t *testing.T) {
-	// Create a temp file to act as the crontab
-	tmpFile, err := os.CreateTemp("", "crontab-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp file: %v", err)
-	}
-	defer os.Remove(tmpFile.Name())
-	tmpFile.Close()
-
-	crontab := &Crontab{
-		IsUserCrontab: false, // use file-based save path
-		Filename:      tmpFile.Name(),
-	}
-
-	if crontab.IsSaved {
-		t.Fatal("IsSaved should be false before Save()")
-	}
-
-	err = crontab.Save("* * * * * echo hello\n")
-	if err != nil {
-		t.Fatalf("Save() returned error: %v", err)
-	}
-
-	if !crontab.IsSaved {
-		t.Errorf("IsSaved should be true after Save(), but it is still false (pointer receiver bug)")
-	}
-}
 
 func TestLineWriteWithNoStdoutAndEnv(t *testing.T) {
 	// Save original viper value

--- a/lib/crontab_test.go
+++ b/lib/crontab_test.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -240,6 +241,34 @@ func TestLineWriteWithEnvFlag(t *testing.T) {
 
 	// Restore original viper value
 	viper.Set("CRONITOR_ENV", originalEnv)
+}
+
+func TestSaveSetsIsSaved(t *testing.T) {
+	// Create a temp file to act as the crontab
+	tmpFile, err := os.CreateTemp("", "crontab-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	crontab := &Crontab{
+		IsUserCrontab: false, // use file-based save path
+		Filename:      tmpFile.Name(),
+	}
+
+	if crontab.IsSaved {
+		t.Fatal("IsSaved should be false before Save()")
+	}
+
+	err = crontab.Save("* * * * * echo hello\n")
+	if err != nil {
+		t.Fatalf("Save() returned error: %v", err)
+	}
+
+	if !crontab.IsSaved {
+		t.Errorf("IsSaved should be true after Save(), but it is still false (pointer receiver bug)")
+	}
 }
 
 func TestLineWriteWithNoStdoutAndEnv(t *testing.T) {

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -4,11 +4,9 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"time"
 )
 
 func randomMinute() int {
-	rand.Seed(time.Now().Unix())
 	return rand.Intn(59)
 }
 

--- a/lib/utils_test.go
+++ b/lib/utils_test.go
@@ -1,0 +1,28 @@
+package lib
+
+import (
+	"testing"
+)
+
+func TestRandomMinuteRange(t *testing.T) {
+	// Verify randomMinute returns values in the valid range [0, 59)
+	for i := 0; i < 100; i++ {
+		result := randomMinute()
+		if result < 0 || result >= 59 {
+			t.Errorf("randomMinute() returned %d, expected value in range [0, 59)", result)
+		}
+	}
+}
+
+func TestRandomMinuteNotConstant(t *testing.T) {
+	// Verify randomMinute produces varying output (not stuck on a single value).
+	// With 20 calls, getting the same value every time is astronomically unlikely
+	// if the RNG is properly seeded.
+	seen := make(map[int]bool)
+	for i := 0; i < 20; i++ {
+		seen[randomMinute()] = true
+	}
+	if len(seen) < 2 {
+		t.Errorf("randomMinute() returned the same value %d times in a row, RNG may not be working", 20)
+	}
+}


### PR DESCRIPTION
- Remove deprecated rand.Seed() call in lib/utils.go (#21). Since Go 1.20+ the global rand is automatically seeded, and the per-call re-seeding was actually causing identical values within the same second.

- Change Crontab.Save from value receiver to pointer receiver so that setting c.IsSaved = true actually persists on the caller's struct (#22).

- Add tests for both fixes.
