### PR TITLE
Bump cronitor's go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cronitorio/cronitor-cli
 
-go 1.23.4
+go 1.26.2
 
 require (
 	github.com/capnspacehook/taskmaster v0.0.0-20210519235353-1629df7c85e9


### PR DESCRIPTION
This is due to critical vulnerability 
https://app.opencve.io/cve/CVE-2026-27143
https://nvd.nist.gov/vuln/detail/CVE-2026-27143