### PR TITLE
Fix build version for 1.26 + Bump to 33.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -92,7 +92,7 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           asset_name: ${{ matrix.goos }}_${{ matrix.goarch }}
-          goversion: 1.23.4
+          goversion: '${{ github.workspace }}/go.mod'
           binary_name: cronitor
           sha256sum: true
           overwrite: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: actions/setup-go@v3
+        with:
+          go-version-file: '${{ github.workspace }}/go.mod'
 
       # Prefer MSYS2 bash to git bash
       - name:  "add-path"
@@ -73,6 +75,8 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: actions/setup-go@v3
+        with:
+          go-version-file: '${{ github.workspace }}/go.mod'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var Version string = "33.2"
+var Version string = "33.4"
 
 var cfgFile string
 var userAgent string


### PR DESCRIPTION
Release of 33.3 did not properly set the go version in the github actions. This fixes that by tying all actions to go.mod.
The version id was also not bumped in cmd/root.go. The tagged 33.3 release also seems to have been misapplied to older commits. Since 33.3 is buggged, this increases to 33.4